### PR TITLE
Add support for saved_change_to_<attr>

### DIFF
--- a/lib/hstore_accessor/macro.rb
+++ b/lib/hstore_accessor/macro.rb
@@ -84,6 +84,17 @@ module HstoreAccessor
               send("#{key}_change").present?
             end
 
+            define_method("saved_change_to_#{key}") do
+              hstore_changes = mutations_before_last_save.change_to_attribute(hstore_attribute)
+              return if hstore_changes.nil?
+              attribute_changes = hstore_changes.map { |change| change.try(:[], store_key.to_s) }
+              attribute_changes.uniq.size == 1 ? nil : attribute_changes
+            end
+
+            define_method("saved_change_to_#{key}?") do
+              send("saved_change_to_#{key}").present?
+            end
+
             define_method("#{key}_was") do
               (send(:attribute_was, hstore_attribute.to_s) || {})[key.to_s]
             end

--- a/spec/hstore_accessor_spec.rb
+++ b/spec/hstore_accessor_spec.rb
@@ -595,6 +595,14 @@ describe HstoreAccessor do
   describe "dirty tracking" do
     let(:product) { Product.new }
 
+    it "save_changed_to_<attr>? should return the expected value" do
+      expect(product.saved_change_to_color?).to be false
+      product.color = "ORANGE"
+      product.save
+      expect(product.saved_change_to_price?).to be false
+      expect(product.saved_change_to_color?).to be true
+    end
+
     it "<attr>_changed? should return the expected value" do
       expect(product.color_changed?).to be false
       product.color = "ORANGE"


### PR DESCRIPTION
New dirty tracking for Rails 5.1 + 5.2 in after callbacks. Gets at least one aspect of issue #76